### PR TITLE
Refactor pipeline architecture and add configurable judge gating

### DIFF
--- a/docs/v2_architecture.md
+++ b/docs/v2_architecture.md
@@ -6,13 +6,14 @@ Build an end-to-end phishing detector that can reason over the full attack chain
 
 `email text/html -> embedded URL -> remote page -> downloaded/attached payload`.
 
-## Pipeline
+## Pipeline (current)
 
-1. Input normalization (`tools/preprocessing.py`)
-1. URL and domain analysis (`tools/url_analysis.py`, `tools/domain_intel.py`)
-1. Attachment deep analysis (`tools/attachment_analysis.py`)
-1. Multi-modal risk fusion (`agents/risk_fusion.py`)
-1. Agent orchestration (`agents/service.py`)
+1. Input normalization and EML/JSON parsing (`domain/email/parse.py`).
+1. Header and URL/domain evidence extraction (`tools/intel/*`, `domain/url/*`).
+1. Conditional deep context collection via safe URL fetch and attachment static/deep analysis (`tools/url_fetch/service.py`, `tools/attachment/analyze.py`).
+1. Evidence pack assembly (`orchestrator/pipeline.py::_build_evidence_pack`).
+1. Planner + executor + judge orchestration (`agents/pipeline/*`).
+1. Fallback or merged final verdict (`agents/pipeline/router.py`).
 
 ## Security-first execution model
 
@@ -30,6 +31,16 @@ Build an end-to-end phishing detector that can reason over the full attack chain
 - `indicators`: merged text/url/attachment/chain indicators
 - `evidence`: deterministic reports for URLs/domains/attachments and component scores
 - `precheck`: raw deterministic analyzer output for reproducible experiments
+
+Judge input is redacted evidence pack to reduce prompt injection and sensitive data exposure.
+
+## Architectural updates in this round
+
+- Added explicit `PipelineRuntime` contract (`agents/pipeline/runtime.py`) to decouple stages from service internals.
+- Extracted evidence assembly into dedicated stage module (`agents/pipeline/evidence_stage.py`).
+- Judge invocation is now route-gated (`review/deep`) instead of always-on when remote model exists.
+- Added configurable `allow`-route judge gating (`never|sampled|always`, deterministic sampling).
+- Updated architecture docs to align with real module paths and runtime composition.
 
 ## Research extension points
 

--- a/src/phish_email_detection_agent/agents/build.py
+++ b/src/phish_email_detection_agent/agents/build.py
@@ -23,6 +23,9 @@ def create_agent(
         context_trigger_score=env_cfg.context_trigger_score,
         suspicious_min_score=env_cfg.suspicious_min_score,
         suspicious_max_score=env_cfg.suspicious_max_score,
+        judge_allow_mode=env_cfg.judge_allow_mode,
+        judge_allow_sample_rate=env_cfg.judge_allow_sample_rate,
+        judge_allow_sample_salt=env_cfg.judge_allow_sample_salt,
     ).normalized()
     agent = AgentService(
         provider=env_cfg.provider,
@@ -99,6 +102,9 @@ def create_agent(
         "context_trigger_score": env_cfg.context_trigger_score,
         "suspicious_min_score": env_cfg.suspicious_min_score,
         "suspicious_max_score": env_cfg.suspicious_max_score,
+        "judge_allow_mode": env_cfg.judge_allow_mode,
+        "judge_allow_sample_rate": env_cfg.judge_allow_sample_rate,
+        "judge_allow_sample_salt": env_cfg.judge_allow_sample_salt,
         "agents_sdk": True,
         "config": yaml_cfg,
     }

--- a/src/phish_email_detection_agent/agents/pipeline/__init__.py
+++ b/src/phish_email_detection_agent/agents/pipeline/__init__.py
@@ -1,15 +1,19 @@
 """Modular agent pipeline stages."""
 
 from phish_email_detection_agent.agents.pipeline.evidence_builder import EvidenceBuilder
+from phish_email_detection_agent.agents.pipeline.evidence_stage import EvidenceStage
 from phish_email_detection_agent.agents.pipeline.executor import PipelineExecutor
 from phish_email_detection_agent.agents.pipeline.judge import JudgeEngine
 from phish_email_detection_agent.agents.pipeline.policy import PipelinePolicy
 from phish_email_detection_agent.agents.pipeline.planner import Planner
+from phish_email_detection_agent.agents.pipeline.runtime import PipelineRuntime
 
 __all__ = [
     "EvidenceBuilder",
+    "EvidenceStage",
     "PipelineExecutor",
     "JudgeEngine",
     "PipelinePolicy",
     "Planner",
+    "PipelineRuntime",
 ]

--- a/src/phish_email_detection_agent/agents/pipeline/evidence_builder.py
+++ b/src/phish_email_detection_agent/agents/pipeline/evidence_builder.py
@@ -5,15 +5,15 @@ from __future__ import annotations
 from typing import Any, Callable
 
 from phish_email_detection_agent.domain.evidence import EvidencePack
+from phish_email_detection_agent.agents.pipeline.runtime import PipelineRuntime
 
 
-BuildEvidenceFn = Callable[[Any, Any], tuple[EvidencePack, dict[str, Any]]]
+BuildEvidenceFn = Callable[[Any, PipelineRuntime], tuple[EvidencePack, dict[str, Any]]]
 
 
 class EvidenceBuilder:
     def __init__(self, build_fn: BuildEvidenceFn) -> None:
         self._build_fn = build_fn
 
-    def build(self, email: Any, service: Any) -> tuple[EvidencePack, dict[str, Any]]:
+    def build(self, email: Any, service: PipelineRuntime) -> tuple[EvidencePack, dict[str, Any]]:
         return self._build_fn(email, service)
-

--- a/src/phish_email_detection_agent/agents/pipeline/evidence_stage.py
+++ b/src/phish_email_detection_agent/agents/pipeline/evidence_stage.py
@@ -1,0 +1,278 @@
+"""Evidence-building stage implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import time
+from typing import Any, Callable
+
+from phish_email_detection_agent.domain.email.models import EmailInput
+from phish_email_detection_agent.domain.evidence import EvidencePack
+
+
+@dataclass(frozen=True)
+class EvidenceStage:
+    extract_urls_from_html_fn: Callable[[str], dict[str, Any]]
+    extract_urls_fn: Callable[[str], list[str]]
+    summarize_chain_flags_fn: Callable[[EmailInput], list[str]]
+    analyze_headers_fn: Callable[..., dict[str, Any]]
+    safe_fetch_policy_fn: Callable[[Any], Any]
+    attachment_policy_fn: Callable[[Any], Any]
+    domain_policy_fn: Callable[[Any], Any]
+    infer_url_signals_fn: Callable[..., tuple[list[dict[str, Any]], list[dict[str, Any]]]]
+    build_nlp_cues_fn: Callable[[EmailInput], dict[str, Any]]
+    build_attachment_signals_fn: Callable[[list[str]], list[dict[str, Any]]]
+    compute_pre_score_fn: Callable[..., dict[str, Any]]
+    should_collect_deep_context_fn: Callable[[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]], int], bool]
+    build_web_signals_fn: Callable[..., tuple[list[dict[str, Any]], list[dict[str, Any]]]]
+    analyze_attachments_fn: Callable[..., dict[str, Any]]
+    enrich_attachments_with_static_scan_fn: Callable[[list[dict[str, Any]], dict[str, Any]], list[str]]
+    clip_score_fn: Callable[[int], int]
+
+    def build(self, email: EmailInput, service: Any) -> tuple[EvidencePack, dict[str, Any]]:
+        timings: dict[str, int] = {}
+        provenance: dict[str, list[str]] = {"limits_hit": [], "errors": []}
+
+        safe_fetch_policy = self.safe_fetch_policy_fn(service)
+        attachment_policy = self.attachment_policy_fn(service)
+        domain_policy = self.domain_policy_fn(service)
+
+        t_start = time.perf_counter()
+        html_url_meta = self.extract_urls_from_html_fn(email.body_html or "")
+        combined_urls = list(
+            dict.fromkeys(email.urls + self.extract_urls_fn(email.text) + self.extract_urls_fn(email.body_text))
+        )
+        combined_urls = list(dict.fromkeys(combined_urls + html_url_meta["urls"]))
+        chain_flags = self.summarize_chain_flags_fn(email)
+        if html_url_meta["hidden_links"]:
+            chain_flags.append("hidden_html_links")
+        timings["parse"] = int((time.perf_counter() - t_start) * 1000)
+
+        t_header = time.perf_counter()
+        header_signals = self.analyze_headers_fn(
+            headers=email.headers,
+            headers_raw=email.headers_raw,
+            sender=email.sender,
+            reply_to=email.reply_to,
+        )
+        timings["header_intel"] = int((time.perf_counter() - t_header) * 1000)
+
+        t_url = time.perf_counter()
+        url_signals, domain_reports = self.infer_url_signals_fn(
+            combined_urls,
+            service=service,
+            fetch_policy=safe_fetch_policy,
+            domain_policy=domain_policy,
+            provenance=provenance,
+        )
+        timings["url_intel"] = int((time.perf_counter() - t_url) * 1000)
+
+        t_nlp = time.perf_counter()
+        nlp_cues = self.build_nlp_cues_fn(email)
+        timings["nlp_cues"] = int((time.perf_counter() - t_nlp) * 1000)
+
+        t_att = time.perf_counter()
+        attachment_signals = self.build_attachment_signals_fn(email.attachments)
+        timings["attachment_prescan"] = int((time.perf_counter() - t_att) * 1000)
+
+        pre_score = self.compute_pre_score_fn(
+            header_signals=header_signals,
+            url_signals=url_signals,
+            web_signals=[],
+            attachment_signals=attachment_signals,
+            nlp_cues=nlp_cues,
+            review_threshold=service.pipeline_policy.pre_score_review_threshold,
+            deep_threshold=service.pipeline_policy.pre_score_deep_threshold,
+            url_suspicious_weight=service.precheck_url_suspicious_weight,
+        )
+
+        deep_trigger = self.should_collect_deep_context_fn(
+            pre_score,
+            url_signals,
+            attachment_signals,
+            service.pipeline_policy.context_trigger_score,
+        )
+
+        web_signals: list[dict[str, Any]] = []
+        url_target_reports: list[dict[str, Any]] = []
+        attachment_bundle: dict[str, Any] = {
+            "reports": [],
+            "risky": [],
+            "risky_count": 0,
+            "extracted_urls": [],
+        }
+
+        if deep_trigger:
+            t_web = time.perf_counter()
+            web_signals, url_target_reports = self.build_web_signals_fn(
+                url_signals,
+                fetch_policy=safe_fetch_policy,
+                provenance=provenance,
+            )
+            timings["web_snapshot"] = int((time.perf_counter() - t_web) * 1000)
+
+            t_att_deep = time.perf_counter()
+            attachment_bundle = self.analyze_attachments_fn(email.attachments, policy=attachment_policy)
+            nested_urls = self.enrich_attachments_with_static_scan_fn(attachment_signals, attachment_bundle)
+            if nested_urls:
+                chain_flags.append("nested_url_in_attachment")
+            timings["attachment_intel"] = int((time.perf_counter() - t_att_deep) * 1000)
+
+            if nested_urls:
+                extra_signals, extra_domain_reports = self.infer_url_signals_fn(
+                    nested_urls,
+                    service=service,
+                    fetch_policy=safe_fetch_policy,
+                    domain_policy=domain_policy,
+                    provenance=provenance,
+                )
+                if extra_signals:
+                    url_signals.extend(extra_signals)
+                    domain_reports.extend(extra_domain_reports)
+
+            pre_score = self.compute_pre_score_fn(
+                header_signals=header_signals,
+                url_signals=url_signals,
+                web_signals=web_signals,
+                attachment_signals=attachment_signals,
+                nlp_cues=nlp_cues,
+                review_threshold=service.pipeline_policy.pre_score_review_threshold,
+                deep_threshold=service.pipeline_policy.pre_score_deep_threshold,
+                url_suspicious_weight=service.precheck_url_suspicious_weight,
+            )
+
+        email_meta = {
+            "message_id": email.message_id,
+            "date": email.date,
+            "sender": email.sender,
+            "to": email.to,
+            "cc": email.cc,
+            "subject": email.subject,
+            "reply_to": email.reply_to,
+            "return_path": email.return_path,
+            "urls_count": len(url_signals),
+            "attachments_count": len(attachment_signals),
+        }
+
+        evidence_pack = EvidencePack.model_validate(
+            {
+                "email_meta": email_meta,
+                "header_signals": header_signals,
+                "url_signals": url_signals,
+                "web_signals": web_signals,
+                "attachment_signals": attachment_signals,
+                "nlp_cues": nlp_cues,
+                "pre_score": pre_score,
+                "provenance": {
+                    "timing_ms": timings,
+                    "limits_hit": list(dict.fromkeys(provenance["limits_hit"])),
+                    "errors": list(dict.fromkeys(provenance["errors"])),
+                },
+            }
+        )
+
+        suspicious_urls = [
+            str(item.get("url", ""))
+            for item in url_signals
+            if isinstance(item, dict) and item.get("risk_flags")
+        ]
+        risky_attachments = [
+            str(item.get("filename", ""))
+            for item in attachment_signals
+            if isinstance(item, dict) and item.get("risk_flags")
+        ]
+        indicators = list(dict.fromkeys(pre_score.get("reasons", []) + chain_flags))
+
+        text_score = int(
+            (
+                float(nlp_cues.get("urgency", 0.0))
+                + float(nlp_cues.get("threat_language", 0.0))
+                + float(nlp_cues.get("payment_or_giftcard", 0.0))
+                + float(nlp_cues.get("credential_request", 0.0))
+            )
+            / 4
+            * 100
+        )
+        url_score = max(
+            [
+                self.clip_score_fn(len(item.get("risk_flags", [])) * 14)
+                for item in url_signals
+                if isinstance(item, dict)
+            ],
+            default=0,
+        )
+        domain_score = max(
+            [int(item.get("risk_score", 0)) for item in domain_reports if isinstance(item, dict)],
+            default=0,
+        )
+        attachment_score = max(
+            [
+                self.clip_score_fn(len(item.get("risk_flags", [])) * 15)
+                for item in attachment_signals
+                if isinstance(item, dict)
+            ],
+            default=0,
+        )
+        ocr_score = max(
+            [
+                int(item.get("details", {}).get("risk_score", 0))
+                for item in attachment_bundle.get("reports", [])
+                if isinstance(item, dict) and item.get("type") == "image"
+            ],
+            default=0,
+        )
+
+        precheck = {
+            "chain_flags": list(dict.fromkeys(chain_flags)),
+            "hidden_links": html_url_meta["hidden_links"],
+            "combined_urls": list(dict.fromkeys([str(item.get("url", "")) for item in url_signals if item.get("url")])),
+            "url_checks": [
+                {"url": str(item.get("url", "")), "suspicious": bool(item.get("risk_flags"))}
+                for item in url_signals
+                if isinstance(item, dict)
+            ],
+            "url_target_reports": url_target_reports,
+            "domain_reports": domain_reports,
+            "attachment_checks": [
+                {
+                    "name": str(item.get("filename", "")),
+                    "risk_score": self.clip_score_fn(len(item.get("risk_flags", [])) * 16),
+                    "type": str(item.get("mime", "")),
+                }
+                for item in attachment_signals
+                if isinstance(item, dict)
+            ],
+            "attachment_reports": attachment_bundle.get("reports", []),
+            "attachment_extracted_urls": attachment_bundle.get("extracted_urls", []),
+            "keyword_hits": [],
+            "suspicious_urls": list(dict.fromkeys([item for item in suspicious_urls if item])),
+            "risky_attachments": list(dict.fromkeys([item for item in risky_attachments if item])),
+            "indicators": indicators,
+            "component_scores": {
+                "text": text_score,
+                "url": url_score,
+                "domain": self.clip_score_fn(domain_score),
+                "attachment": attachment_score,
+                "ocr": self.clip_score_fn(ocr_score),
+            },
+            "heuristic_score": int(evidence_pack.pre_score.risk_score),
+            "fusion": {
+                "risk_score": int(evidence_pack.pre_score.risk_score),
+                "risk_level": (
+                    "high"
+                    if int(evidence_pack.pre_score.risk_score) >= 70
+                    else "medium"
+                    if int(evidence_pack.pre_score.risk_score) >= 35
+                    else "low"
+                ),
+                "verdict": "phishing" if int(evidence_pack.pre_score.risk_score) >= 35 else "benign",
+            },
+            "fetch_policy": {
+                "enabled": safe_fetch_policy.enabled,
+                "backend": safe_fetch_policy.sandbox_backend,
+                "allow_private_network": safe_fetch_policy.allow_private_network,
+                "max_bytes": safe_fetch_policy.max_bytes,
+                "max_redirects": safe_fetch_policy.max_redirects,
+            },
+        }
+        return evidence_pack, precheck

--- a/src/phish_email_detection_agent/agents/pipeline/judge.py
+++ b/src/phish_email_detection_agent/agents/pipeline/judge.py
@@ -13,6 +13,7 @@ from phish_email_detection_agent.agents.pipeline.router import (
     merge_judge_verdict,
     normalize_score_for_verdict,
 )
+from phish_email_detection_agent.agents.pipeline.runtime import PipelineRuntime
 from phish_email_detection_agent.agents.prompts import JUDGE_PROMPT
 from phish_email_detection_agent.evidence.redact import redact_value
 
@@ -28,7 +29,7 @@ class JudgeEngine:
     def evaluate(
         self,
         *,
-        service: Any,
+        service: PipelineRuntime,
         email: Any,
         evidence_pack: Any,
         precheck: dict[str, Any],
@@ -37,7 +38,7 @@ class JudgeEngine:
         try:
             from agents import Agent, AgentOutputSchema, Runner
 
-            common = service._build_common_kwargs()
+            common = service.build_common_kwargs()
             judge_agent = Agent(
                 name="argis-evidence-judge-agent",
                 instructions=JUDGE_PROMPT,

--- a/src/phish_email_detection_agent/agents/pipeline/planner.py
+++ b/src/phish_email_detection_agent/agents/pipeline/planner.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import hashlib
 
+from phish_email_detection_agent.agents.pipeline.policy import PipelinePolicy
 from phish_email_detection_agent.agents.pipeline.router import map_route_to_path
 from phish_email_detection_agent.domain.evidence import EvidencePack
 
@@ -18,22 +20,64 @@ class ExecutionPlan:
 
 
 class Planner:
+    def _sample_allow_route(self, *, evidence_pack: EvidencePack, policy: PipelinePolicy) -> bool:
+        sample_rate = float(policy.judge_allow_sample_rate)
+        if sample_rate <= 0:
+            return False
+        fingerprint = "|".join(
+            [
+                str(evidence_pack.email_meta.message_id),
+                str(evidence_pack.email_meta.sender),
+                str(evidence_pack.email_meta.subject),
+                str(evidence_pack.email_meta.date),
+                str(evidence_pack.pre_score.risk_score),
+                ",".join(evidence_pack.pre_score.reasons[:4]),
+            ]
+        )
+        token = f"{policy.judge_allow_sample_salt}|{fingerprint}"
+        bucket = int(hashlib.sha256(token.encode("utf-8")).hexdigest()[:8], 16) / float(0xFFFFFFFF)
+        return bucket < sample_rate
+
+    def _should_invoke_judge_for_route(
+        self,
+        *,
+        route: str,
+        evidence_pack: EvidencePack,
+        policy: PipelinePolicy,
+    ) -> bool:
+        clean_route = str(route or "").strip().lower()
+        if clean_route in {"review", "deep"}:
+            return True
+        if clean_route != "allow":
+            return True
+        if policy.judge_allow_mode == "always":
+            return True
+        if policy.judge_allow_mode == "sampled":
+            return self._sample_allow_route(evidence_pack=evidence_pack, policy=policy)
+        return False
+
     def plan(
         self,
         *,
         evidence_pack: EvidencePack,
         has_content: bool,
         can_call_remote: bool,
+        pipeline_policy: PipelinePolicy | None = None,
     ) -> ExecutionPlan:
+        active_policy = (pipeline_policy or PipelinePolicy()).normalized()
         route = str(evidence_pack.pre_score.route)
         reasons = list(evidence_pack.pre_score.reasons)
         if not reasons:
             reasons = ["no_strong_signals"]
+        should_invoke_judge = has_content and can_call_remote and self._should_invoke_judge_for_route(
+            route=route,
+            evidence_pack=evidence_pack,
+            policy=active_policy,
+        )
         return ExecutionPlan(
             has_content=has_content,
             route=route,
             path=map_route_to_path(route),
-            should_invoke_judge=has_content and can_call_remote,
+            should_invoke_judge=should_invoke_judge,
             reasons=reasons,
         )
-

--- a/src/phish_email_detection_agent/agents/pipeline/policy.py
+++ b/src/phish_email_detection_agent/agents/pipeline/policy.py
@@ -14,6 +14,9 @@ class PipelinePolicy:
     suspicious_max_score: int = 34
     judge_promote_low_to_suspicious_confidence: float = 0.75
     judge_override_mid_band_confidence: float = 0.58
+    judge_allow_mode: str = "never"
+    judge_allow_sample_rate: float = 0.0
+    judge_allow_sample_salt: str = "argis"
 
     def normalized(self) -> "PipelinePolicy":
         review = max(1, int(self.pre_score_review_threshold))
@@ -21,6 +24,9 @@ class PipelinePolicy:
         context = max(1, int(self.context_trigger_score))
         suspicious_min = max(1, int(self.suspicious_min_score))
         suspicious_max = max(suspicious_min, int(self.suspicious_max_score))
+        allow_mode = str(self.judge_allow_mode or "").strip().lower()
+        if allow_mode not in {"never", "sampled", "always"}:
+            allow_mode = "never"
         return PipelinePolicy(
             pre_score_review_threshold=review,
             pre_score_deep_threshold=deep,
@@ -33,4 +39,7 @@ class PipelinePolicy:
             judge_override_mid_band_confidence=max(
                 0.0, min(1.0, float(self.judge_override_mid_band_confidence))
             ),
+            judge_allow_mode=allow_mode,
+            judge_allow_sample_rate=max(0.0, min(1.0, float(self.judge_allow_sample_rate))),
+            judge_allow_sample_salt=str(self.judge_allow_sample_salt or "argis"),
         )

--- a/src/phish_email_detection_agent/agents/pipeline/runtime.py
+++ b/src/phish_email_detection_agent/agents/pipeline/runtime.py
@@ -1,0 +1,27 @@
+"""Pipeline runtime contracts used by planner/executor/judge stages."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from phish_email_detection_agent.agents.pipeline.policy import PipelinePolicy
+
+
+class PipelineRuntime(Protocol):
+    """Minimal runtime surface required by pipeline stages."""
+
+    provider: str
+    max_turns: int
+    pipeline_policy: PipelinePolicy
+
+    def can_call_remote(self) -> bool: ...
+
+    def build_common_kwargs(self) -> dict[str, object]: ...
+
+    def event(
+        self,
+        stage: str,
+        status: str,
+        message: str,
+        data: dict[str, Any] | None = None,
+    ) -> dict[str, Any]: ...

--- a/src/phish_email_detection_agent/config/defaults.yaml
+++ b/src/phish_email_detection_agent/config/defaults.yaml
@@ -43,6 +43,9 @@ pre_score_deep_threshold: 70
 context_trigger_score: 35
 suspicious_min_score: 30
 suspicious_max_score: 34
+judge_allow_mode: never
+judge_allow_sample_rate: 0.0
+judge_allow_sample_salt: argis
 
 profiles:
   openai:
@@ -100,6 +103,9 @@ profiles:
     context_trigger_score: 35
     suspicious_min_score: 30
     suspicious_max_score: 34
+    judge_allow_mode: never
+    judge_allow_sample_rate: 0.0
+    judge_allow_sample_salt: argis
 
   ollama:
     provider: local
@@ -159,3 +165,6 @@ profiles:
     context_trigger_score: 35
     suspicious_min_score: 30
     suspicious_max_score: 34
+    judge_allow_mode: never
+    judge_allow_sample_rate: 0.0
+    judge_allow_sample_salt: argis

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,79 @@
+from phish_email_detection_agent.agents.pipeline.planner import Planner
+from phish_email_detection_agent.agents.pipeline.policy import PipelinePolicy
+from phish_email_detection_agent.domain.evidence import EvidencePack
+
+
+def _make_evidence(route: str) -> EvidencePack:
+    return EvidencePack.model_validate(
+        {
+            "email_meta": {},
+            "header_signals": {},
+            "pre_score": {"risk_score": 10, "route": route, "reasons": ["unit:test"]},
+        }
+    )
+
+
+def test_planner_skips_judge_for_allow_route():
+    planner = Planner()
+    plan = planner.plan(evidence_pack=_make_evidence("allow"), has_content=True, can_call_remote=True)
+    assert plan.should_invoke_judge is False
+
+
+def test_planner_invokes_judge_for_review_route():
+    planner = Planner()
+    plan = planner.plan(evidence_pack=_make_evidence("review"), has_content=True, can_call_remote=True)
+    assert plan.should_invoke_judge is True
+
+
+def test_planner_skips_judge_without_content():
+    planner = Planner()
+    plan = planner.plan(evidence_pack=_make_evidence("deep"), has_content=False, can_call_remote=True)
+    assert plan.should_invoke_judge is False
+
+
+def test_planner_can_always_judge_allow_route():
+    planner = Planner()
+    policy = PipelinePolicy(judge_allow_mode="always")
+    plan = planner.plan(
+        evidence_pack=_make_evidence("allow"),
+        has_content=True,
+        can_call_remote=True,
+        pipeline_policy=policy,
+    )
+    assert plan.should_invoke_judge is True
+
+
+def test_planner_can_sample_allow_route():
+    planner = Planner()
+    policy = PipelinePolicy(judge_allow_mode="sampled", judge_allow_sample_rate=1.0, judge_allow_sample_salt="unit")
+    plan = planner.plan(
+        evidence_pack=_make_evidence("allow"),
+        has_content=True,
+        can_call_remote=True,
+        pipeline_policy=policy,
+    )
+    assert plan.should_invoke_judge is True
+
+
+def test_planner_sampled_allow_route_respects_zero_rate():
+    planner = Planner()
+    policy = PipelinePolicy(judge_allow_mode="sampled", judge_allow_sample_rate=0.0, judge_allow_sample_salt="unit")
+    plan = planner.plan(
+        evidence_pack=_make_evidence("allow"),
+        has_content=True,
+        can_call_remote=True,
+        pipeline_policy=policy,
+    )
+    assert plan.should_invoke_judge is False
+
+
+def test_policy_invalid_allow_mode_normalizes_to_never():
+    planner = Planner()
+    policy = PipelinePolicy(judge_allow_mode="random_mode", judge_allow_sample_rate=1.0, judge_allow_sample_salt="unit")
+    plan = planner.plan(
+        evidence_pack=_make_evidence("allow"),
+        has_content=True,
+        can_call_remote=True,
+        pipeline_policy=policy,
+    )
+    assert plan.should_invoke_judge is False


### PR DESCRIPTION
## Summary
- extract deterministic evidence assembly into dedicated EvidenceStage
- add PipelineRuntime contract and reduce stage coupling to service internals
- make judge invocation policy configurable for allow route (never|sampled|always)
- wire new judge policy options through config/defaults/build runtime
- refresh architecture docs and extend planner coverage tests

## Validation
- uv run pytest tests/test_planner.py tests/test_pipeline_smoke.py tests/test_policy.py
- uv run ruff check src tests